### PR TITLE
ATtiny202対応

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -39,12 +39,12 @@ https://www.arduino.cc/reference/en/language/functions/usb/keyboard/
 
 == ATtiny202 (or MCU with small flash) support ==
 ATtiny202のようなフラッシュサイズが2KB以下のマイコンでは、print関数を無効化することでフラッシュ使用量を削減しています。
-これは、`_AVR_FLASH`マクロ使用して自動で判定されます。`_AVR_FLASH`マクロはmegaTinyCoreで使えます。
+これは、`FLASHEND`マクロ使用して自動で判定されます。
 
 *前述の通り、フラッシュサイズが2KB以下の場合は、print関数が使用出来ません。*
 
 For microcontrollers with a flash size of 2KB or less, such as the ATtiny202, the flash usage is reduced by disabling the print function.
-This is automatically determined by using the `_AVR_FLASH` macro. The `_AVR_FLASH` macro can be used with megaTinyCore.
+This is automatically determined by using the `FLASHEND` macro.
 
 *As mentioned above, if the flash size is less than 2KB, the print function cannot be used. *
 

--- a/README.adoc
+++ b/README.adoc
@@ -37,6 +37,17 @@ void setup() {
 For more information about the original Keyboard library please visit
 https://www.arduino.cc/reference/en/language/functions/usb/keyboard/
 
+== ATtiny202 (or MCU with small flash) support ==
+ATtiny202のようなフラッシュサイズが2KB以下のマイコンでは、print関数を無効化することでフラッシュ使用量を削減しています。
+これは、`_AVR_FLASH`マクロ使用して自動で判定されます。`_AVR_FLASH`マクロはmegaTinyCoreで使えます。
+
+*前述の通り、フラッシュサイズが2KB以下の場合は、print関数が使用出来ません。*
+
+For microcontrollers with a flash size of 2KB or less, such as the ATtiny202, the flash usage is reduced by disabling the print function.
+This is automatically determined by using the `_AVR_FLASH` macro. The `_AVR_FLASH` macro can be used with megaTinyCore.
+
+*As mentioned above, if the flash size is less than 2KB, the print function cannot be used. *
+
 == Acknowledgements ==
 いちかわ(ICHI) https://twitter.com/atsuyuki1kawa[(Twitter)] さんが公開している  https://sites.google.com/site/ichiworkspace/%E3%83%9B%E3%83%BC%E3%83%A0/%E3%81%BF%E3%82%93%E3%81%AA%E3%81%AE%E3%83%A9%E3%83%9C/%E3%82%AD%E3%83%BC%E3%83%9C%E3%83%BC%E3%83%89%E3%83%9E%E3%82%A6%E3%82%B9%E3%82%A8%E3%83%9F%E3%83%A5%E3%83%AC%E3%83%BC%E3%82%BF[和訳したデータシート]はとても役に立ちました。
 

--- a/src/CH9329_Keyboard.h
+++ b/src/CH9329_Keyboard.h
@@ -125,7 +125,7 @@ typedef struct
   uint8_t keys[6];
 } KeyReport;
 
-#if defined(_AVR_FLASH) && _AVR_FLASH <= 2
+#if defined(FLASHEND) && FLASHEND <= 0x7FF
 class CH9329_Keyboard_ 
 #else
 class CH9329_Keyboard_ : public Print

--- a/src/CH9329_Keyboard.h
+++ b/src/CH9329_Keyboard.h
@@ -125,7 +125,11 @@ typedef struct
   uint8_t keys[6];
 } KeyReport;
 
+#if defined(_AVR_FLASH) && _AVR_FLASH <= 2
+class CH9329_Keyboard_ 
+#else
 class CH9329_Keyboard_ : public Print
+#endif
 {
 private:
   KeyReport _keyReport;


### PR DESCRIPTION
ATtiny202のようなフラッシュサイズの小さいマイコンの場合は、Printを継承しないようして、フラッシュサイズを削減するように変更。

megaTinyCoreでテスト済。
`_AVR_FLASH`マクロを使用しているので、ATtiny202以外のmegaTinyCore対応マイコンで、フラッシュサイズが2KB以下の場合に、Printを継承しないようにして容量削減を実現。